### PR TITLE
fix compatibility of php 8.1

### DIFF
--- a/Slim/Collection.php
+++ b/Slim/Collection.php
@@ -122,6 +122,7 @@ class Collection implements CollectionInterface
      *
      * @return mixed The key's value, or the default value
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->get($key);


### PR DESCRIPTION
* fix: add #[\ReturnTypeWillChange] to ignore deprecation notices